### PR TITLE
Set customCommandArgs type to array

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -58,7 +58,10 @@
 					"description": "For a custom backend, the command to execute when launching the server"
 				},
 				"crystal-ide.customCommandArgs": {
-					"type": "string",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
 					"default": ["run", "src/scry"],
 					"description": "For a custom backend, the arguments passed to the command"
 				},


### PR DESCRIPTION
Hello! @kofno
This PR fix a warning in settings.json
`Incorrect type: Expected "string"`

Can you publish a new version of Crystal-IDE to VSCode Marketplace?

Bye! :raising_hand_man: 
