### PR TITLE
onDidOpen and decodeURI

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -68,13 +68,13 @@ connection.onDidChangeConfiguration((change) => {
 });
 
 function fileUriToPath(uri: string) : string {
-	return uri.replace("file://", "");
+	return decodeURI(uri.replace("file://", ""));
 }
 
 function validateFile(file: FileChanged): void {
 	let exec = require('child_process').exec;
 	let diagnostics: Diagnostic[] = [];
-	exec("crystal build --no-color --no-codegen -f json --release " + fileUriToPath(file.uri), (err, response) => {
+	exec("crystal build --no-color --no-codegen -f json --release \"" + fileUriToPath(file.uri) + "\"", (err, response) => {
 		if (response) {
 			let results = JSON.parse(response);
 			let length = Math.min(maxNumberOfProblems, results.length);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -37,7 +37,7 @@ connection.onInitialize((params): InitializeResult => {
 
 // The content of a text document has changed. This event is emitted
 // when the text document first opened or when its content has changed.
-documents.onDidChangeContent((change) => {
+documents.onDidOpen((change) => {
 	validateFile(change.document);
 });
 


### PR DESCRIPTION
Hi @kofno , thanks you for v0.0.4!

**onDidOpen** is better that **onDidChangeContent** because  validateFile checks the _filepath_ instead of _textDocument_.

Also `ctrl+s` is needed for correct linting because **onDidChangeWatchedFiles** is doing all the hard work.

And finally this improve the performance because don't call crystal compiler each time when the code is changed.

Bye! :raising_hand_man: 
### Update (2016-10-25)

Support filepath with spaces or special characters like :point_down: 

```
crystal build --no-color --no-codegen -f json --release "/home/user/Español Veragüense/test.cr"
```
