### PR TITLE
Fix link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Visual Studio Code.
 
 Crystal IDE is implemented using the Language Server Protocol.
 
-[A blog post about Language Server Protocol](https://code.visualstudio.com/blogs#_any-language-any-tool)
+[A blog post about Language Server Protocol](https://code.visualstudio.com/blogs/2016/06/27/common-language-protocol)
 
 
 ## Dependencies


### PR DESCRIPTION
This current link is broken and routes to the top blog entry of the VS Code page.  I believe this is the correct blog entry that should be linked to